### PR TITLE
Make it compatible with Rails 4.2

### DIFF
--- a/lib/angular_rails_csrf/concern.rb
+++ b/lib/angular_rails_csrf/concern.rb
@@ -11,7 +11,11 @@ module AngularRailsCsrf
     end
 
     def verified_request?
-      super || form_authenticity_token == request.headers['X-XSRF-TOKEN']
+      if respond_to?(:valid_authenticity_token?, true)
+        super || valid_authenticity_token?(session, request.headers['X-XSRF-TOKEN'])
+      else
+        super || form_authenticity_token == request.headers['X-XSRF-TOKEN']
+      end
     end
   end
 end


### PR DESCRIPTION
In Rails 4.2 has been changed a way verifying a request and validating an authenticity token. Compare
https://github.com/rails/rails/blob/master/actionpack/lib/action_controller/metal/request_forgery_protection.rb
https://github.com/rails/rails/blob/4-1-stable/actionpack/lib/action_controller/metal/request_forgery_protection.rb

My change brings a compatibility with Rails 4.2, 4.1 and 4.0. Please, release a new version after accepting this PR, if possible.
