### PR TITLE
Change after_filter to before_filter so that gem works with Live Streaming

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    angular_rails_csrf (1.0.3)
+    angular_rails_csrf (1.0.4)
       rails (>= 3, < 5)
 
 GEM
@@ -35,12 +35,12 @@ GEM
     builder (3.1.4)
     erubis (2.7.0)
     hike (1.2.3)
-    i18n (0.6.11)
+    i18n (0.7.0)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
     mime-types (2.4.3)
     minitest (4.7.5)
-    multi_json (1.10.1)
+    multi_json (1.11.0)
     rack (1.5.2)
     rack-test (0.6.2)
       rack (>= 1.0)
@@ -68,7 +68,7 @@ GEM
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
     thor (0.19.1)
-    thread_safe (0.3.4)
+    thread_safe (0.3.5)
     tilt (1.4.1)
     tzinfo (0.3.42)
 

--- a/lib/angular_rails_csrf/concern.rb
+++ b/lib/angular_rails_csrf/concern.rb
@@ -3,7 +3,7 @@ module AngularRailsCsrf
     extend ActiveSupport::Concern
 
     included do
-      after_filter :set_xsrf_token_cookie
+      before_filter :set_xsrf_token_cookie
     end
 
     def set_xsrf_token_cookie

--- a/lib/angular_rails_csrf/version.rb
+++ b/lib/angular_rails_csrf/version.rb
@@ -1,3 +1,3 @@
 module AngularRailsCsrf
-  VERSION = "1.0.3"
+  VERSION = "1.0.4"
 end


### PR DESCRIPTION
Details can be found here: https://github.com/jsanders/angular_rails_csrf/issues/7

Thanks to @baweaver for the suggestion. I originally wrote a class method to allow exceptions, and realized it wasn't needed. If you want that anyways, I can make a separate PR.