### PR TITLE
Use after_filter to prevent session change

### DIFF
--- a/lib/angular_rails_csrf/concern.rb
+++ b/lib/angular_rails_csrf/concern.rb
@@ -3,7 +3,7 @@ module AngularRailsCsrf
     extend ActiveSupport::Concern
 
     included do
-      before_filter :set_xsrf_token_cookie
+      after_filter :set_xsrf_token_cookie
     end
 
     def set_xsrf_token_cookie

--- a/lib/angular_rails_csrf/concern.rb
+++ b/lib/angular_rails_csrf/concern.rb
@@ -3,7 +3,8 @@ module AngularRailsCsrf
     extend ActiveSupport::Concern
 
     included do
-      after_filter :set_xsrf_token_cookie
+      before_filter :set_xsrf_token_cookie
+      after_filter :set_xsrf_token_cookie, unless: -> { response.committed? }
     end
 
     def set_xsrf_token_cookie

--- a/lib/angular_rails_csrf/concern.rb
+++ b/lib/angular_rails_csrf/concern.rb
@@ -4,7 +4,7 @@ module AngularRailsCsrf
 
     included do
       before_filter :set_xsrf_token_cookie
-      after_filter :set_xsrf_token_cookie, unless: -> { response.committed? }
+      after_filter :set_xsrf_token_cookie, unless: -> { response.committed? if response.respond_to?(:committed?) }
     end
 
     def set_xsrf_token_cookie

--- a/lib/angular_rails_csrf/concern.rb
+++ b/lib/angular_rails_csrf/concern.rb
@@ -3,7 +3,6 @@ module AngularRailsCsrf
     extend ActiveSupport::Concern
 
     included do
-      before_filter :set_xsrf_token_cookie
       after_filter :set_xsrf_token_cookie, unless: -> { response.committed? if response.respond_to?(:committed?) }
     end
 


### PR DESCRIPTION
Some action like user sign_in or sign_out will reset session, so use after_filter instead.