### PR TITLE
Changing set_xsrf_token_cookie to be an after_filter

### DIFF
--- a/lib/angular_rails_csrf/concern.rb
+++ b/lib/angular_rails_csrf/concern.rb
@@ -3,7 +3,7 @@ module AngularRailsCsrf
     extend ActiveSupport::Concern
 
     included do
-      before_filter :set_xsrf_token_cookie
+      after_filter :set_xsrf_token_cookie
     end
 
     def set_xsrf_token_cookie

--- a/lib/angular_rails_csrf/version.rb
+++ b/lib/angular_rails_csrf/version.rb
@@ -1,3 +1,3 @@
 module AngularRailsCsrf
-  VERSION = "1.0.4"
+  VERSION = '1.0.5'
 end


### PR DESCRIPTION
From version 3.0.1 onwards devise clears the XSRF token after a successful login. The current behaviour of angular_rails_csrf was to add a header before the controller action. This resulted in the concern adding a csrf token that was then invalidate by the controller inside the same action.
Subsequent calls to protected APIs would result in a 422 error due to a token invalid exception.

By changing method `set_xsrf_token` to be an `after_filter` we make sure that we add the token only after the controller code has been executed, and thus the token added is always a valid one.

I also changed the version to 1.0.5, but feel free to discard the change.