### PR TITLE
Allow gem to work with Rails 5 and update deprecated method

### DIFF
--- a/angular_rails_csrf.gemspec
+++ b/angular_rails_csrf.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |s|
     s.add_development_dependency 'rails', ENV['TEST_RAILS_VERSION'].to_s
   end
 
-  s.add_runtime_dependency 'rails', '>= 3', '< 5'
+  s.add_runtime_dependency 'rails', '>= 3', '>= 5'
 end

--- a/angular_rails_csrf.gemspec
+++ b/angular_rails_csrf.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |s|
     s.add_development_dependency 'rails', ENV['TEST_RAILS_VERSION'].to_s
   end
 
-  s.add_runtime_dependency 'rails', '>= 3', '>= 5'
+  s.add_runtime_dependency 'railties', '>= 3', '>= 5'
 end

--- a/lib/angular_rails_csrf/concern.rb
+++ b/lib/angular_rails_csrf/concern.rb
@@ -3,7 +3,7 @@ module AngularRailsCsrf
     extend ActiveSupport::Concern
 
     included do
-      before_filter :set_xsrf_token_cookie
+      before_action :set_xsrf_token_cookie
     end
 
     def set_xsrf_token_cookie


### PR DESCRIPTION
I have this working with my Rails 5 app, using a gem hosted on my github: https://github.com/AlanDonohoe/angular_rails_csrf

Thought it would be good to get the Rails 5 fix into this version.