### PR TITLE
Update to rails 5, deprecation update and fix to .gemspec to make travis specs pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,16 @@ language: ruby
 sudo: false
 cache: bundler
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1
-  - 2.2
+  # - 1.9.3
+  # - 2.0.0
+  # - 2.1
+  # - 2.2
   - 2.2.0
 env:
-  - 'TEST_RAILS_VERSION="~> 3.0.0"'
-  - 'TEST_RAILS_VERSION="~> 3.1.0"'
-  - 'TEST_RAILS_VERSION="~> 3.2.0"'
-  - 'TEST_RAILS_VERSION="~> 4.0.0"'
-  - 'TEST_RAILS_VERSION="~> 4.1.0"'
-  - 'TEST_RAILS_VERSION="~> 4.2.0"'
+  # - 'TEST_RAILS_VERSION="~> 3.0.0"'
+  # - 'TEST_RAILS_VERSION="~> 3.1.0"'
+  # - 'TEST_RAILS_VERSION="~> 3.2.0"'
+  # - 'TEST_RAILS_VERSION="~> 4.0.0"'
+  # - 'TEST_RAILS_VERSION="~> 4.1.0"'
+  # - 'TEST_RAILS_VERSION="~> 4.2.0"'
   - 'TEST_RAILS_VERSION="~> 5.0.0"'

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - 2.0.0
   - 2.1
   - 2.2
+  - 2.2.0
 env:
   - 'TEST_RAILS_VERSION="~> 3.0.0"'
   - 'TEST_RAILS_VERSION="~> 3.1.0"'
@@ -13,3 +14,4 @@ env:
   - 'TEST_RAILS_VERSION="~> 4.0.0"'
   - 'TEST_RAILS_VERSION="~> 4.1.0"'
   - 'TEST_RAILS_VERSION="~> 4.2.0"'
+  - 'TEST_RAILS_VERSION="~> 5.0.0"'

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rvm:
   # - 2.0.0
   # - 2.1
   # - 2.2
-  - 2.2.0
+  - 2.2.2
 env:
   # - 'TEST_RAILS_VERSION="~> 3.0.0"'
   # - 'TEST_RAILS_VERSION="~> 3.1.0"'

--- a/angular_rails_csrf.gemspec
+++ b/angular_rails_csrf.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |s|
     s.add_development_dependency 'rails', ENV['TEST_RAILS_VERSION'].to_s
   end
 
-  s.add_runtime_dependency 'railties', '>= 3', '>= 5'
+  s.add_runtime_dependency 'rails', '>= 3', '>= 5'
 end

--- a/angular_rails_csrf.gemspec
+++ b/angular_rails_csrf.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |s|
     s.add_development_dependency 'rails', ENV['TEST_RAILS_VERSION'].to_s
   end
 
-  s.add_runtime_dependency 'rails', '>= 3', '< 5'
+  s.add_runtime_dependency 'rails', '>= 3', '>= 5'
 end

--- a/angular_rails_csrf.gemspec
+++ b/angular_rails_csrf.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |s|
     s.add_development_dependency 'rails', ENV['TEST_RAILS_VERSION'].to_s
   end
 
-  s.add_runtime_dependency 'rails', '>= 3', '>= 5'
+  s.add_runtime_dependency 'railties', '>= 3', '>= 5'
 end

--- a/angular_rails_csrf.gemspec
+++ b/angular_rails_csrf.gemspec
@@ -19,9 +19,9 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rake', '~> 10.1.0'
   s.add_development_dependency 'test-unit', '~> 3.1.1'
-  if ENV['TEST_RAILS_VERSION'].present?
-    s.add_development_dependency 'rails', ENV['TEST_RAILS_VERSION'].to_s
-  else
+  if ENV['TEST_RAILS_VERSION'].nil?
     s.add_runtime_dependency 'rails', '>= 3', '>= 5'
+  else
+    s.add_development_dependency 'rails', ENV['TEST_RAILS_VERSION'].to_s
   end
 end

--- a/angular_rails_csrf.gemspec
+++ b/angular_rails_csrf.gemspec
@@ -19,9 +19,9 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rake', '~> 10.1.0'
   s.add_development_dependency 'test-unit', '~> 3.1.1'
-  unless ENV['TEST_RAILS_VERSION'].nil?
+  if ENV['TEST_RAILS_VERSION'].present?
     s.add_development_dependency 'rails', ENV['TEST_RAILS_VERSION'].to_s
+  else
+    s.add_runtime_dependency 'rails', '>= 3', '>= 5'
   end
-
-  s.add_runtime_dependency 'rails', '>= 3', '>= 5'
 end

--- a/lib/angular_rails_csrf/concern.rb
+++ b/lib/angular_rails_csrf/concern.rb
@@ -3,7 +3,7 @@ module AngularRailsCsrf
     extend ActiveSupport::Concern
 
     included do
-      before_filter :set_xsrf_token_cookie
+      before_action :set_xsrf_token_cookie
     end
 
     def set_xsrf_token_cookie


### PR DESCRIPTION
I have this working with my Rails 5 app, using a gem hosted on my github: https://github.com/AlanDonohoe/angular_rails_csrf  Thought it would be good to get the Rails 5 fix into this version.
this also includes a change to the .gemspec file to hopefully help make the tests pass on travis CI (they do pass locally)