### PR TITLE
Exclude for certain actions and revert for after_filter. Closes #17

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ test/dummy/tmp/
 test/dummy/.sass-cache
 Gemfile.lock
 .idea/
+*.gem

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,6 @@
 source "https://rubygems.org"
 
 gemspec
+
+# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
+gem 'tzinfo-data', platforms: [:mingw, :mswin]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Note that there is nothing AngularJS specific here, and this will work with any 
 
 ### Installation
 
-Add this line to your application's Gemfile:
+Add this line to your application's *Gemfile*:
 
     gem 'angular_rails_csrf'
 
@@ -20,3 +20,15 @@ And then execute:
     $ bundle
 
 That's it!
+
+### Exclusions
+
+Sometimes you will want to skip setting the XSRF token for certain controllers (for example, when using SSE or ActionCable, as discussed [here](https://github.com/jsanders/angular_rails_csrf/issues/7)):
+
+```ruby
+class ExclusionsController < ApplicationController
+  exclude_xsrf_token_cookie
+  
+  # your actions here...
+end
+```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ## AngularJS-style CSRF Protection for Rails
 
 [![Build Status](https://travis-ci.org/jsanders/angular_rails_csrf.png)](https://travis-ci.org/jsanders/angular_rails_csrf)
+[![Dependency Status](https://gemnasium.com/badges/github.com/jsanders/angular_rails_csrf.svg)](https://gemnasium.com/github.com/jsanders/angular_rails_csrf)
 
 The AngularJS [ng.$http](http://docs.angularjs.org/api/ng.$http) service has built-in CSRF protection. By default, it looks for a cookie named `XSRF-TOKEN` and, if found, writes its value into an `X-XSRF-TOKEN` header, which the server compares with the CSRF token saved in the user's session.
 

--- a/angular_rails_csrf.gemspec
+++ b/angular_rails_csrf.gemspec
@@ -21,7 +21,9 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rake', '~> 11.3'
   s.add_development_dependency 'test-unit', '~> 3.2'
-  unless ENV['TEST_RAILS_VERSION'].nil?
+  if ENV['TEST_RAILS_VERSION'].nil?
+    s.add_development_dependency 'rails', '5.0.0.1'
+  else
     s.add_development_dependency 'rails', ENV['TEST_RAILS_VERSION'].to_s
   end
 

--- a/lib/angular_rails_csrf/concern.rb
+++ b/lib/angular_rails_csrf/concern.rb
@@ -4,14 +4,16 @@ module AngularRailsCsrf
 
     included do
       if Rails::VERSION::MAJOR < 4
-        before_filter :set_xsrf_token_cookie
+        after_filter :set_xsrf_token_cookie
       else
-        before_action :set_xsrf_token_cookie
+        after_action :set_xsrf_token_cookie
       end
     end
 
     def set_xsrf_token_cookie
-      cookies['XSRF-TOKEN'] = form_authenticity_token if protect_against_forgery?
+      if protect_against_forgery? && !respond_to?(:__exclude_xsrf_token_cookie?)
+        cookies['XSRF-TOKEN'] = form_authenticity_token
+      end
     end
 
     def verified_request?
@@ -19,6 +21,16 @@ module AngularRailsCsrf
         super || valid_authenticity_token?(session, request.headers['X-XSRF-TOKEN'])
       else
         super || form_authenticity_token == request.headers['X-XSRF-TOKEN']
+      end
+    end
+
+    module ClassMethods
+      def exclude_xsrf_token_cookie
+        self.class_eval do
+          def __exclude_xsrf_token_cookie?
+            true
+          end
+        end
       end
     end
   end

--- a/test/angular_rails_csrf_exception_test.rb
+++ b/test/angular_rails_csrf_exception_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+
+class AngularRailsCsrfExceptionTest < ActionController::TestCase
+  tests ExclusionsController
+
+  setup do
+    @controller.allow_forgery_protection = true
+    @correct_token = @controller.send(:form_authenticity_token)
+  end
+
+  test "a get does not set the XSRF-TOKEN cookie" do
+    get :index
+    assert_not_equal @correct_token, cookies['XSRF-TOKEN']
+    assert_response :success
+  end
+end

--- a/test/dummy/app/controllers/exclusions_controller.rb
+++ b/test/dummy/app/controllers/exclusions_controller.rb
@@ -1,0 +1,5 @@
+class ExclusionsController < ApplicationController
+  exclude_xsrf_token_cookie
+
+  def index;  head :ok; end
+end

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,4 +1,6 @@
 Dummy::Application.routes.draw do
   get  'test' => 'application#index'
   post 'test' => 'application#create'
+
+  get 'exclusions' => 'exclusions#index'
 end


### PR DESCRIPTION
For controller that don't need CSRF token there is a class method `exclude_xsrf_token_cookie` as suggested here https://github.com/dimroc/angular_rails_csrf/commit/7a0e848fb77c5dbc04d129e4bd0486f1bb6ac798