### PR TITLE
Accept request header without case-sensitivity

### DIFF
--- a/lib/angular_rails_csrf/concern.rb
+++ b/lib/angular_rails_csrf/concern.rb
@@ -17,10 +17,12 @@ module AngularRailsCsrf
     end
 
     def verified_request?
+      downcase_headers = request.headers.to_a.map { |v| [v.first.downcase, v.last] }.to_h
+
       if respond_to?(:valid_authenticity_token?, true)
-        super || valid_authenticity_token?(session, request.headers['X-XSRF-TOKEN'])
+        super || valid_authenticity_token?(session, downcase_headers['x-xsrf-token'])
       else
-        super || form_authenticity_token == request.headers['X-XSRF-TOKEN']
+        super || form_authenticity_token == downcase_headers['x-xsrf-token']
       end
     end
 

--- a/test/angular_rails_csrf_test.rb
+++ b/test/angular_rails_csrf_test.rb
@@ -29,13 +29,20 @@ class AngularRailsCsrfTest < ActionController::TestCase
     assert_response :success
   end
 
+  test "a post is accepted if X-XSRF-TOKEN is set properly, regardless of case" do
+    set_header_to @controller.send(:form_authenticity_token), 'x-XsRf-TOKEN'
+    post :create
+    assert_valid_cookie
+    assert_response :success
+  end
+
   private
 
   # Helpers
 
-  def set_header_to(value)
+  def set_header_to(value, key = 'X-XSRF-TOKEN')
     # Rails 3 uses `env` and Rails 4 uses `headers`
-    @request.env['X-XSRF-TOKEN'] = @request.headers['X-XSRF-TOKEN'] = value
+    @request.env[key] = @request.headers[key] = value
   end
 
   def assert_valid_cookie


### PR DESCRIPTION
Hey @jsanders, I'm working with a GraphQL client implementation that downcases all request headers... since I guess they're [supposed to be case-insensitive](https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2). 