### PR TITLE
Allow domain for cookie to be set

### DIFF
--- a/lib/angular_rails_csrf/concern.rb
+++ b/lib/angular_rails_csrf/concern.rb
@@ -12,7 +12,9 @@ module AngularRailsCsrf
 
     def set_xsrf_token_cookie
       if protect_against_forgery? && !respond_to?(:__exclude_xsrf_token_cookie?)
-        cookies['XSRF-TOKEN'] = form_authenticity_token
+        config = Rails.application.config
+        domain = config.respond_to?(:angular_rails_csrf_domain) ? config.angular_rails_csrf_domain : nil
+        cookies['XSRF-TOKEN'] = { value: form_authenticity_token, domain: domain }
       end
     end
 

--- a/test/angular_rails_csrf_test.rb
+++ b/test/angular_rails_csrf_test.rb
@@ -7,6 +7,17 @@ class AngularRailsCsrfTest < ActionController::TestCase
     get :index
     assert_valid_cookie
     assert_response :success
+    assert_equal @response.headers['Set-Cookie'].include?('.test.host'), false
+  end
+
+  test "the domain is used if present" do
+    config = Rails.application.config
+    def config.angular_rails_csrf_domain; :all; end
+
+    get :index
+    assert @response.headers['Set-Cookie'].include?('.test.host')
+    assert_valid_cookie
+    assert_response :success
   end
 
   test "a post raises an error without the X-XSRF-TOKEN header set" do


### PR DESCRIPTION
Why: So that the cookie can be shared across subdomains for example.