### PR TITLE
Allow custom cookie name to be set

### DIFF
--- a/lib/angular_rails_csrf/concern.rb
+++ b/lib/angular_rails_csrf/concern.rb
@@ -10,7 +10,8 @@ module AngularRailsCsrf
       if protect_against_forgery? && !respond_to?(:__exclude_xsrf_token_cookie?)
         config = Rails.application.config
         domain = config.respond_to?(:angular_rails_csrf_domain) ? config.angular_rails_csrf_domain : nil
-        cookies['XSRF-TOKEN'] = { value: form_authenticity_token, domain: domain }
+        cookie_name = config.respond_to?(:angular_rails_csrf_cookie_name) ? config.angular_rails_csrf_cookie_name : 'XSRF-TOKEN'
+        cookies[cookie_name] = { value: form_authenticity_token, domain: domain }
       end
     end
 


### PR DESCRIPTION
Hi there,

This is to help managing cookies to a more granular level. For instance when dealing with different apps on the same domain.

Not the cleanest, but I couldn't find a better way with minitest to set, and then unset, `angular_rails_csrf_cookie_name`, hence the block with an `undef`. 