### PR TITLE
Allow provision of csrf cookie secure flag

### DIFF
--- a/lib/angular_rails_csrf/concern.rb
+++ b/lib/angular_rails_csrf/concern.rb
@@ -12,9 +12,15 @@ module AngularRailsCsrf
       return unless protect_against_forgery? && !respond_to?(:__exclude_xsrf_token_cookie?)
 
       config = Rails.application.config
-      domain = config.respond_to?(:angular_rails_csrf_domain) ? config.angular_rails_csrf_domain : nil
+
+      cookie_options = {
+        value: form_authenticity_token,
+        domain: config.respond_to?(:angular_rails_csrf_domain) ? config.angular_rails_csrf_domain : nil
+      }
+      cookie_options[:secure] = config.angular_rails_csrf_secure if config.respond_to?(:angular_rails_csrf_secure)
+
       cookie_name = config.respond_to?(:angular_rails_csrf_cookie_name) ? config.angular_rails_csrf_cookie_name : 'XSRF-TOKEN'
-      cookies[cookie_name] = {value: form_authenticity_token, domain: domain}
+      cookies[cookie_name] = cookie_options
     end
 
     def verified_request?

--- a/test/angular_rails_csrf_test.rb
+++ b/test/angular_rails_csrf_test.rb
@@ -41,6 +41,23 @@ class AngularRailsCsrfTest < ActionController::TestCase
     assert @response.headers['Set-Cookie'].include?('.test.host')
     assert_valid_cookie
     assert_response :success
+  ensure
+    config.instance_eval('undef :angular_rails_csrf_domain')
+  end
+
+  test 'the secure flag is set if configured' do
+    @request.headers['HTTPS'] = 'on'
+
+    config = Rails.application.config
+    config.define_singleton_method(:angular_rails_csrf_secure) { true }
+
+    get :index
+    assert @response.headers['Set-Cookie'].include?('secure')
+    assert_valid_cookie
+    assert_response :success
+  ensure
+    @request.headers['HTTPS'] = nil
+    config.instance_eval('undef :angular_rails_csrf_secure')
   end
 
   test 'a custom name is used if present' do


### PR DESCRIPTION
This PR adds a new config option `angular_rails_csrf_secure`, which allows you to set the "secure" flag on the cookie.

I also tweaked the existing `angular_rails_csrf_domain` test to remove some test flakiness I was encountering when running tests.