### PR TITLE
Allow SameSite cookie attribute to be set

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ class Application < Rails::Application
 end
 ```
 
-**NOTE**: When using `SameSite=None` you should also set `Secure`. Use the above `angular_rails_csrf_secure` config for that.
+**NOTE**: When using `SameSite=None`, this gem automatically sets the cookie to `Secure`.
 
 ### Exclusions
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,20 @@ end
 
 `angular_rails_csrf_secure` defaults to `false`.
 
+### SameSite
+
+The SameSite attribute now defaults to `:lax`. You can override this in the config:
+
+```ruby
+# application.rb
+class Application < Rails::Application
+  #...
+  config.angular_rails_csrf_same_site = :strict
+end
+```
+
+**NOTE**: When using `SameSite=None` you should also set `Secure`. Use the above `angular_rails_csrf_secure` config for that.
+
 ### Exclusions
 
 Sometimes you will want to skip setting the XSRF token for certain controllers (for example, when using SSE or ActionCable, as discussed [here](https://github.com/jsanders/angular_rails_csrf/issues/7)):

--- a/lib/angular_rails_csrf/concern.rb
+++ b/lib/angular_rails_csrf/concern.rb
@@ -15,7 +15,8 @@ module AngularRailsCsrf
 
       cookie_options = {
         value: form_authenticity_token,
-        domain: config.respond_to?(:angular_rails_csrf_domain) ? config.angular_rails_csrf_domain : nil
+        domain: config.respond_to?(:angular_rails_csrf_domain) ? config.angular_rails_csrf_domain : nil,
+        same_site: config.respond_to?(:angular_rails_csrf_same_site) ? config.angular_rails_csrf_same_site : :lax
       }
       cookie_options[:secure] = config.angular_rails_csrf_secure if config.respond_to?(:angular_rails_csrf_secure)
 

--- a/lib/angular_rails_csrf/concern.rb
+++ b/lib/angular_rails_csrf/concern.rb
@@ -13,12 +13,15 @@ module AngularRailsCsrf
 
       config = Rails.application.config
 
+      same_site = config.respond_to?(:angular_rails_csrf_same_site) ? config.angular_rails_csrf_same_site : :lax
+      secure = config.angular_rails_csrf_secure if config.respond_to?(:angular_rails_csrf_secure)
+
       cookie_options = {
         value: form_authenticity_token,
         domain: config.respond_to?(:angular_rails_csrf_domain) ? config.angular_rails_csrf_domain : nil,
-        same_site: config.respond_to?(:angular_rails_csrf_same_site) ? config.angular_rails_csrf_same_site : :lax
+        same_site: same_site,
+        secure: same_site == :none || secure
       }
-      cookie_options[:secure] = config.angular_rails_csrf_secure if config.respond_to?(:angular_rails_csrf_secure)
 
       cookie_name = config.respond_to?(:angular_rails_csrf_cookie_name) ? config.angular_rails_csrf_cookie_name : 'XSRF-TOKEN'
       cookies[cookie_name] = cookie_options

--- a/test/angular_rails_csrf_test.rb
+++ b/test/angular_rails_csrf_test.rb
@@ -94,6 +94,23 @@ class AngularRailsCsrfTest < ActionController::TestCase
     end
   end
 
+  test 'secure is set automatically when same_site is set to none' do
+    begin
+      @request.headers['HTTPS'] = 'on'
+
+      config = Rails.application.config
+      config.define_singleton_method(:angular_rails_csrf_same_site) { :none }
+
+      get :index
+      assert @response.headers['Set-Cookie'].include?('SameSite=None')
+      assert @response.headers['Set-Cookie'].include?('secure')
+      assert_valid_cookie
+      assert_response :success
+    ensure
+      config.instance_eval('undef :angular_rails_csrf_same_site', __FILE__, __LINE__)
+    end
+  end
+
   private
 
   # Helpers

--- a/test/angular_rails_csrf_test.rb
+++ b/test/angular_rails_csrf_test.rb
@@ -73,6 +73,27 @@ class AngularRailsCsrfTest < ActionController::TestCase
     end
   end
 
+  test 'same_site is set to Lax by default' do
+      get :index
+      assert @response.headers['Set-Cookie'].include?('SameSite=Lax')
+      assert_valid_cookie
+      assert_response :success
+  end
+
+  test 'same_site can be configured' do
+    begin
+      config = Rails.application.config
+      config.define_singleton_method(:angular_rails_csrf_same_site) { :strict }
+
+      get :index
+      assert @response.headers['Set-Cookie'].include?('SameSite=Strict')
+      assert_valid_cookie
+      assert_response :success
+    ensure
+      config.instance_eval('undef :angular_rails_csrf_same_site', __FILE__, __LINE__)
+    end
+  end
+
   private
 
   # Helpers


### PR DESCRIPTION
Changes to how browsers will handle the default `SameSite` attribute
means it's generally considered better to explicitly set it. Lax is
what browsers will start to default to.

I wonder if `SameSite=None; Secure` should be enforced in this gem? I could add that to this.

Happy to hear your thoughts on this PR.

Further reading:
https://www.chromium.org/updates/same-site

https://tools.ietf.org/html/draft-west-cookie-incrementalism-00

https://web.dev/samesite-cookie-recipes/