### PR TITLE
check that protect_against_forgery? defined

### DIFF
--- a/lib/angular_rails_csrf/concern.rb
+++ b/lib/angular_rails_csrf/concern.rb
@@ -9,7 +9,7 @@ module AngularRailsCsrf
     end
 
     def set_xsrf_token_cookie
-      return unless protect_against_forgery? && !respond_to?(:__exclude_xsrf_token_cookie?)
+      return unless defined?(protect_against_forgery?) && protect_against_forgery? && !respond_to?(:__exclude_xsrf_token_cookie?)
 
       config = Rails.application.config
 

--- a/test/angular_rails_csrf_skip_test.rb
+++ b/test/angular_rails_csrf_skip_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class AngularRailsCsrfSkipTest < ActionController::TestCase
+  tests ApiController
+
+  test 'csrf-cookie is not set and no error if protect_against_forgery? is not defined' do
+    refute @controller.respond_to?(:protect_against_forgery?)
+    get :index
+    assert_nil cookies['XSRF-TOKEN']
+    assert_response :success
+  end
+
+end

--- a/test/dummy/app/controllers/api_controller.rb
+++ b/test/dummy/app/controllers/api_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ApiController < ActionController::API
+  def index
+    head :ok
+  end
+end

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -5,4 +5,6 @@ Dummy::Application.routes.draw do
   post 'test' => 'application#create'
 
   get 'exclusions' => 'exclusions#index'
+
+  get 'index' => 'api#index'
 end


### PR DESCRIPTION
In some cases controllers doesn't have "protect_against_forgery?" defined, this leads to error in patched line.
Met that in Doorkeeper::TokensController from https://github.com/doorkeeper-gem/doorkeeper.

And disabling with exclude_xsrf_token_cookie doesn't work due to order of conditions.