### PR TITLE
Add HttpOnly option to cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,20 @@ end
 
 Please note that [Safari is known to have issues](https://bugs.webkit.org/show_bug.cgi?id=198181) with SameSite attribute set to `:none`.
 
+### HttpOnly Cookie
+
+To set a "httponly" flag for the cookie, set the `angular_rails_csrf_httponly` option to `true`:
+
+```ruby
+# application.rb
+class Application < Rails::Application
+  #...
+  config.angular_rails_csrf_httponly = true
+end
+```
+
+`angular_rails_csrf_httponly` defaults to `false`.
+
 ### Exclusions
 
 Sometimes you will want to skip setting the XSRF token for certain controllers (for example, when using SSE or ActionCable, as discussed [here](https://github.com/jsanders/angular_rails_csrf/issues/7)):

--- a/lib/angular_rails_csrf/concern.rb
+++ b/lib/angular_rails_csrf/concern.rb
@@ -14,12 +14,14 @@ module AngularRailsCsrf
       config = Rails.application.config
 
       same_site = same_site_from config
+      httponly = httponly_from config
       secure = secure_from config
 
       cookie_options = {
         value: form_authenticity_token,
         domain: domain_from(config),
         same_site: same_site,
+        httponly: httponly,
         secure: same_site.eql?(:none) || secure
       }
 
@@ -35,6 +37,10 @@ module AngularRailsCsrf
 
     def same_site_from(config)
       config.respond_to?(:angular_rails_csrf_same_site) ? config.angular_rails_csrf_same_site : :lax
+    end
+
+    def httponly_from(config)
+      config.respond_to?(:angular_rails_csrf_httponly) ? config.angular_rails_csrf_httponly : false
     end
 
     def secure_from(config)

--- a/test/angular_rails_csrf_test.rb
+++ b/test/angular_rails_csrf_test.rb
@@ -78,6 +78,18 @@ class AngularRailsCsrfTest < ActionController::TestCase
     end
   end
 
+  test 'the httponly flag is set if configured' do
+    config = Rails.application.config
+    config.define_singleton_method(:angular_rails_csrf_httponly) { true }
+
+    get :index
+    assert @response.headers['Set-Cookie'].include?('HttpOnly')
+    assert_valid_cookie
+    assert_response :success
+  ensure
+    config.instance_eval('undef :angular_rails_csrf_httponly', __FILE__, __LINE__)
+  end
+
   test 'same_site is set to Lax by default' do
     get :index
     assert @response.headers['Set-Cookie'].include?('SameSite=Lax')


### PR DESCRIPTION
### Summary

Implement the missing option `angular_rails_csrf_httponly` to add the `HttpOnly` flag to the cookie.
